### PR TITLE
Fix decoding issue with Arrays

### DIFF
--- a/lib/avro_ex/decode.ex
+++ b/lib/avro_ex/decode.ex
@@ -169,8 +169,10 @@ defmodule AvroEx.Decode do
   def do_decode(%Array{items: item_schema}, %Context{} = context, data) when is_binary(data) do
     {count, buffer} = do_decode(%Primitive{type: :long}, context, data)
 
+    times = if count > 0, do: 1..count, else: []
+
     {decoded_items, rest} =
-      Enum.reduce(1..count, {[], buffer}, fn _, {decoded_items, buffer} ->
+      Enum.reduce(times, {[], buffer}, fn _, {decoded_items, buffer} ->
         {decoded_item, buffer} = do_decode(item_schema, context, buffer)
         {[decoded_item | decoded_items], buffer}
       end)

--- a/test/decode_test.exs
+++ b/test/decode_test.exs
@@ -161,6 +161,41 @@ defmodule AvroEx.Decode.Test do
       {:ok, encoded_sha} = AvroEx.encode(schema, sha)
       assert {:ok, ^sha} = @test_module.decode(schema, encoded_sha)
     end
+
+    test "record with empty array of records" do
+      {:ok, schema} = AvroEx.parse_schema(~S(
+        {
+          "type": "record",
+          "name": "User",
+          "fields": [
+            {
+              "name": "friends",
+              "type": {
+                "type": "array",
+                "items": {
+                  "type": "record",
+                  "name": "Friend",
+                  "fields": [
+                    {
+                      "name": "userId",
+                      "type": "string"
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "name": "username",
+              "type": "string"
+            }
+          ]
+        }
+      ))
+
+      {:ok, encoded} = AvroEx.encode(schema, %{"friends" => [], "username" => "iamauser"})
+
+      assert {:ok, %{"friends" => [], "username" => "iamauser"}} = @test_module.decode(schema, encoded)
+    end
   end
 
   describe "decode logical types" do


### PR DESCRIPTION
When a schema had a top-level array of records, and the schema had another top-level key, and you tried to decode a data structure whose array was empty, you would get an exception:
```
     ** (FunctionClauseError) no function clause matching in AvroEx.Decode.variable_integer_decode/3

     The following arguments were given to AvroEx.Decode.variable_integer_decode/3:

         # 1
         ""

         # 2
         ""

         # 3
         %AvroEx.Schema.Primitive{metadata: %{}, type: :long}

     Attempted function clauses (showing 3 out of 3):

         def variable_integer_decode(<<0::integer()-size(1), n::integer()-size(7), rest::bitstring()>>, acc, %AvroEx.Schema.Primitive{type: :integer}) when is_bitstring(acc) and is_bitstring(acc)
         def variable_integer_decode(<<0::integer()-size(1), n::integer()-size(7), rest::bitstring()>>, acc, %AvroEx.Schema.Primitive{type: :long}) when is_bitstring(acc) and is_bitstring(acc)
         def variable_integer_decode(<<1::integer()-size(1), n::integer()-size(7), rest::bitstring()>>, acc, type) when is_bitstring(acc) and is_bitstring(acc)

     code: assert {:ok, %{"friends" => [], "username" => "iamauser"}} = @test_module.decode(schema, encoded)
     stacktrace:
       (avro_ex) lib/avro_ex/decode.ex:217: AvroEx.Decode.variable_integer_decode/3
       (avro_ex) lib/avro_ex/decode.ex:103: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:118: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:127: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:139: anonymous fn/3 in AvroEx.Decode.do_decode/3
       (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
       (avro_ex) lib/avro_ex/decode.ex:138: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:176: anonymous fn/4 in AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:175: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:139: anonymous fn/3 in AvroEx.Decode.do_decode/3
       (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
       (avro_ex) lib/avro_ex/decode.ex:138: AvroEx.Decode.do_decode/3
       (avro_ex) lib/avro_ex/decode.ex:11: AvroEx.Decode.decode/2
       test/decode_test.exs:197: (test)
```

This PR fixes the decoding so it doesn't iterate over a `1..0` range.